### PR TITLE
Polaris: Automated PR: Update org.apache.logging.log4j:log4j-core:2.14.1 to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.14.1</version>
+      <version>2.25.4</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Vulnerabilities associated with org.apache.logging.log4j:log4j-core:2.14.1
[CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) *(critical)*: Apache Log4j, as used in many popular services, is vulnerable to improperly allowing lightweight directory access protocol (LDAP) access via Java naming and directory interface (JNDI). A remote attacker able to supply the end application with specially crafted input that is then processed by the Log4j subcomponent could cause the execution of arbitrary Java code.

**Note** 

- log4j-api packages by themselves do not contain the vulnerable functionality and are therefore unaffected. log4j-core packages and the upstream overarching source repository are affected.

- A previously suggested mitigation of setting environment variable `LOG4J_FORMAT_MSG_NO_LOOKUPS=true` is not recommended. This mitigation has been proven inadequate against this vulnerability. 

- This vulnerability is partially fixed in [**2.15.0-rc2**](https://github.com/apache/logging-log4j2/releases/tag/log4j-2.15.0-rc2) by [this](https://github.com/apache/logging-log4j2/commit/001aaada7dab82c3c09cde5f8e14245dc9d8b454) commit and [this](https://github.com/apache/logging-log4j2/commit/bac0d8a35c7e354a0d3f706569116dff6c6bd658) commit. These fixes were deemed incomplete. See BDSA-2021-3779 (CVE-2021-45046) for more details.

This vulnerability is listed as exploitable by the Cybersecurity & Infrastructure Security Agency in their [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).

[Click Here To See More Details On Server](https://poc.polaris.blackduck.com/portfolio/portfolios/c5bcdf83-380a-47d1-b35a-81d216f060c1/portfolio-items/ce21e0c7-35f0-45c1-84f5-28d314de4eae/projects/e8c08df2-ef58-4547-8d69-e35600a99d67/components/84d9ebcd-097e-4a10-b881-5d2f6d8706e3)